### PR TITLE
Initialize Keycloak dev setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.idea/
+__pycache__/
+*.pyc
+*.pyo
+*.log
+*.sqlite

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# Keycloak
+# Keycloak Identity Service
+
+This repository hosts the configuration and infrastructure files to run a Keycloak instance that will serve as the unified authentication service for Bear_Review and Mech-Exo.
+
+## Getting Started
+
+1. Install Docker and Docker Compose.
+2. Run `docker compose up -d` in this directory.
+3. Open `http://localhost:8080/` and log in with user **admin** / **admin**.
+
+The development setup uses a Postgres container to persist data. The `keycloak/realm-export.json` file contains a minimal realm that will be imported on startup.
+
+## Project Overview
+
+This Keycloak instance is planned to integrate with multiple SaaS applications. For more details see the project plan in the repository history.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: keycloak
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: keycloak
+    volumes:
+      - keycloak_db:/var/lib/postgresql/data
+  keycloak:
+    image: quay.io/keycloak/keycloak:24.0
+    command: start-dev --import-realm
+    environment:
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgres/keycloak
+      KC_DB_USERNAME: keycloak
+      KC_DB_PASSWORD: keycloak
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    volumes:
+      - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro
+    ports:
+      - "8080:8080"
+    depends_on:
+      - postgres
+volumes:
+  keycloak_db:

--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -1,0 +1,4 @@
+{
+  "realm": "mysaas",
+  "enabled": true
+}


### PR DESCRIPTION
## Summary
- initialize repository with .gitignore
- add Docker Compose config for Keycloak and Postgres
- add minimal realm-export.json
- expand README with instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ce02e2ef4832a8122dbcc577aa342