### PR TITLE
Add scaling and security configs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,22 @@
+name: Security Scan
+on:
+  pull_request:
+  schedule:
+    - cron: '0 3 * * 1'
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Trivy Image Scan
+        uses: aquasecurity/trivy-action@v0.12.0
+        with:
+          image-ref: ghcr.io/org/bear-review:${{ github.sha }}
+          exit-code: '1'
+          severity: 'HIGH,CRITICAL'
+      - name: Snyk Scan
+        uses: snyk/snyk@master
+        with:
+          command: test
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -1,0 +1,33 @@
+# Scaling and Security Hardening
+
+This document covers the high availability setup for Keycloak and the security controls deployed in phase T7.
+
+## Keycloak High Availability
+
+Two replicas of Keycloak run under the Keycloak Operator. Sessions are stored in the embedded Infinispan cache and data is persisted to an external Postgres RDS instance. The service monitor is enabled for Prometheus scraping.
+
+```yaml
+spec:
+  instances: 2
+  enableServiceMonitor: true
+  cache:
+    stack: infinispan
+    type: embedded
+```
+
+## Nginx Ingress WAF
+
+The ingress controller is configured with ModSecurity and the OWASP CRS. Requests per IP are limited to **20 r/s** via the ConfigMap value `limit-req`. Authentication headers `X-Auth-User` and `X-Auth-Email` are passed to upstream services.
+
+## OIDC Header Injection
+
+`oauth2-proxy` is deployed as a sidecar authentication layer. Upstream applications read `X-User-Id` and `X-Role` headers after authentication.
+
+## Image and Dependency Scanning
+
+- **Trivy** scans container images and blocks releases with HIGH or CRITICAL findings.
+- **Snyk** monitors JavaScript and Python dependencies with a GitHub Action gate.
+
+## Load Testing
+
+k6 scripts under `k6/scripts/` ensure the 95th percentile latency stays below 250&nbsp;ms and the failure rate is under 0.1%.

--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -1,0 +1,16 @@
+resource "aws_db_instance" "keycloak" {
+  identifier              = var.rds_identifier
+  engine                  = "postgres"
+  engine_version          = "14"
+  instance_class          = var.rds_instance_class
+  allocated_storage       = 20
+  username                = "keycloak"
+  password                = var.rds_password
+  db_name                 = "keycloak"
+  multi_az                = true
+  storage_encrypted       = true
+  kms_key_id              = var.rds_kms_key_id
+  vpc_security_group_ids  = [aws_security_group.db.id]
+  backup_retention_period = 7
+  skip_final_snapshot     = true
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -9,3 +9,7 @@ state_bucket = "my-tf-state"
 state_lock_table = "terraform-lock"
 office_cidr = "203.0.113.0/24"
 
+rds_identifier = "keycloak-rds"
+rds_instance_class = "db.t3.medium"
+rds_password = "change-me"
+rds_kms_key_id = "arn:aws:kms:region:acct:key/1234"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -68,3 +68,21 @@ variable "office_cidr" {
   default     = "0.0.0.0/0"
 }
 
+
+variable "rds_identifier" {
+  description = "Identifier for the Keycloak RDS instance"
+}
+
+variable "rds_instance_class" {
+  description = "RDS instance class"
+  default     = "db.t3.medium"
+}
+
+variable "rds_password" {
+  description = "Master password for RDS"
+  sensitive   = true
+}
+
+variable "rds_kms_key_id" {
+  description = "KMS key ID for RDS encryption"
+}

--- a/k6/scripts/auth-login.js
+++ b/k6/scripts/auth-login.js
@@ -1,0 +1,22 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export let options = {
+  stages: [
+    { duration: '1m', target: 500 },
+    { duration: '5m', target: 500 }
+  ],
+  thresholds: {
+    http_req_duration: ['p(95)<250'],
+    checks: ['rate>0.999']
+  }
+};
+
+export default function () {
+  const url = 'https://auth.example.com/realms/master/protocol/openid-connect/token';
+  const payload = 'grant_type=password&client_id=cli&username=test&password=test';
+  const params = { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } };
+  const res = http.post(url, payload, params);
+  check(res, { 'status 200': r => r.status === 200 });
+  sleep(1);
+}

--- a/k8s/ingress/configmap.yaml
+++ b/k8s/ingress/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-custom-settings
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "1"
+data:
+  limit-req: "20r/s"

--- a/k8s/ingress/modsecurity-values.yaml
+++ b/k8s/ingress/modsecurity-values.yaml
@@ -1,0 +1,8 @@
+controller:
+  enableModsecurity: true
+  enableOWASPModsecurityCRS: true
+  config:
+    enable-modsecurity: "true"
+    modsecurity-snippet: |
+      SecRuleEngine On
+    limit-req: "20r/s"

--- a/k8s/keycloak/keycloak-cr.yaml
+++ b/k8s/keycloak/keycloak-cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: kc
+spec:
+  instances: 2
+  enableServiceMonitor: true
+  cache:
+    stack: infinispan
+    type: embedded

--- a/k8s/keycloak/operator-values.yaml
+++ b/k8s/keycloak/operator-values.yaml
@@ -1,0 +1,7 @@
+# Values for installing the Keycloak Operator via Helm
+# Helm repo: https://codecentric.github.io/helm-charts
+image:
+  tag: "24.0.0"
+operator:
+  watchNamespaces:
+    - "keycloak"

--- a/k8s/oauth2-proxy/values.yaml
+++ b/k8s/oauth2-proxy/values.yaml
@@ -1,0 +1,9 @@
+config:
+  existingSecret: oauth2-proxy
+  extraArgs:
+    provider: oidc
+    set-authorization-header: "true"
+    pass-authorization-header: "true"
+    pass-access-token: "true"
+    set-xauthrequest: "true"
+    whitelist-domain: .example.com

--- a/k8s/policies/pod-security.yaml
+++ b/k8s/policies/pod-security.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-privileged
+spec:
+  validationFailureAction: Enforce
+  rules:
+    - name: disallow-privileged
+      match:
+        resources:
+          kinds:
+            - Pod
+      validate:
+        message: "Privileged mode is not allowed"
+        pattern:
+          spec:
+            containers:
+              - =(securityContext):
+                  =(privileged): false
+    - name: require-non-root
+      match:
+        resources:
+          kinds:
+            - Pod
+      validate:
+        message: "Containers must run as non-root"
+        pattern:
+          spec:
+            securityContext:
+              runAsNonRoot: true
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-egress
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to: []
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 5432

--- a/runbooks/keycloak-ha.md
+++ b/runbooks/keycloak-ha.md
@@ -1,0 +1,21 @@
+# Keycloak HA Runbook
+
+This runbook explains how to verify high availability for the Keycloak deployment.
+
+## Pod Failure
+
+1. Delete one of the Keycloak pods:
+   ```bash
+   kubectl delete pod -l app=keycloak -n keycloak --force
+   ```
+2. Ensure a replacement pod becomes Ready within 60 seconds.
+3. Verify sessions remain active by accessing the application.
+
+## RDS Failover
+
+1. Trigger an RDS failover from the AWS console or CLI.
+2. Monitor Keycloak logs for reconnection messages. Average login latency should remain below 5 seconds.
+
+## Alerts
+
+Prometheus alerts `KeycloakUnavailable` should remain below 1 firing instance. Investigate any alert immediately using `kubectl logs` and the RDS monitoring dashboard.


### PR DESCRIPTION
## Summary
- add Keycloak operator sample CR
- configure Nginx WAF values and oauth2-proxy
- provide pod security policies, k6 script and HA runbook
- document hardening steps
- add security scanning workflow
- include Terraform RDS example

## Testing
- `pytest -q`
- `terraform fmt infra/rds.tf`
- `terraform -chdir=infra init -backend=false` *(fails: Invalid expression in main.tf)*

------
https://chatgpt.com/codex/tasks/task_e_684cf70ba864832a977476e77cd0593a