### PR TITLE
Integrate basic auth flow

### DIFF
--- a/apps/bear-review-spa/src/context/AuthProvider.tsx
+++ b/apps/bear-review-spa/src/context/AuthProvider.tsx
@@ -2,10 +2,10 @@ import { createContext, useContext, useState, useEffect, ReactNode } from 'react
 import { UserManager, User } from 'oidc-client-ts';
 
 const config = {
-  authority: 'https://example.com/realms/bear',
+  authority: 'http://localhost:8080/realms/unified-apps-realm',
   client_id: 'bear-review-spa',
-  redirect_uri: window.location.origin,
-  silent_redirect_uri: window.location.origin + '/auth-silent.html',
+  redirect_uri: `${window.location.origin}/callback`,
+  silent_redirect_uri: `${window.location.origin}/auth-silent.html`,
   response_type: 'code',
   scope: 'openid profile',
 };

--- a/bear_review_api/app/routers/reviews.py
+++ b/bear_review_api/app/routers/reviews.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
 from typing import List
+from unified_auth import require_user
 
 class Review(BaseModel):
     id: int | None = None
@@ -11,26 +12,26 @@ router = APIRouter(prefix="/reviews", tags=["reviews"])
 
 FAKE_DB: dict[int, Review] = {}
 
-@router.get("/", response_model=List[Review])
-def list_reviews() -> List[Review]:
+@router.get("/", response_model=List[Review], dependencies=[Depends(require_user)])
+def list_reviews(user=Depends(require_user)) -> List[Review]:
     return list(FAKE_DB.values())
 
-@router.post("/", response_model=Review, status_code=201)
-def create_review(review: Review) -> Review:
+@router.post("/", response_model=Review, status_code=201, dependencies=[Depends(require_user)])
+def create_review(review: Review, user=Depends(require_user)) -> Review:
     review.id = len(FAKE_DB) + 1
     FAKE_DB[review.id] = review
     return review
 
-@router.put("/{review_id}", response_model=Review)
-def update_review(review_id: int, review: Review) -> Review:
+@router.put("/{review_id}", response_model=Review, dependencies=[Depends(require_user)])
+def update_review(review_id: int, review: Review, user=Depends(require_user)) -> Review:
     if review_id not in FAKE_DB:
         raise HTTPException(status_code=404, detail="Not found")
     review.id = review_id
     FAKE_DB[review_id] = review
     return review
 
-@router.delete("/{review_id}", status_code=204)
-def delete_review(review_id: int) -> None:
+@router.delete("/{review_id}", status_code=204, dependencies=[Depends(require_user)])
+def delete_review(review_id: int, user=Depends(require_user)) -> None:
     if review_id in FAKE_DB:
         del FAKE_DB[review_id]
     return None

--- a/python/unified_auth/__init__.py
+++ b/python/unified_auth/__init__.py
@@ -1,2 +1,4 @@
 from .jwt import verify_jwt
-__all__ = ["verify_jwt"]
+from .fastapi import require_user
+
+__all__ = ["verify_jwt", "require_user"]

--- a/python/unified_auth/fastapi.py
+++ b/python/unified_auth/fastapi.py
@@ -1,0 +1,23 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+import os
+from .jwt import verify_jwt
+
+security = HTTPBearer()
+
+async def require_user(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    token = credentials.credentials
+    jwks_url = os.getenv("JWKS_URL")
+    issuer = os.getenv("JWT_ISSUER", "")
+    audience = os.getenv("JWT_AUDIENCE", "")
+
+    if jwks_url:
+        try:
+            user = await verify_jwt(token, jwks_url, issuer, audience)
+        except Exception as e:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED) from e
+        return user
+    # If no JWKS_URL configured, simply return token for local dev
+    if not token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    return {"sub": "dev", "token": token}

--- a/tests/test_reviews.py
+++ b/tests/test_reviews.py
@@ -6,12 +6,13 @@ from fastapi.testclient import TestClient
 client = TestClient(app)
 
 def test_create_and_list_review():
-    resp = client.post('/reviews/', json={'user_id': 1, 'content': 'hello'})
+    headers = {"Authorization": "Bearer testtoken"}
+    resp = client.post('/reviews/', json={'user_id': 1, 'content': 'hello'}, headers=headers)
     assert resp.status_code == 201
     data = resp.json()
     assert data['id'] == 1
 
-    resp = client.get('/reviews/')
+    resp = client.get('/reviews/', headers=headers)
     assert resp.status_code == 200
     items = resp.json()
     assert len(items) == 1


### PR DESCRIPTION
## Summary
- point SPA OIDC client to local Keycloak realm
- add FastAPI dependency that checks for an auth token
- expose `require_user` helper in `unified_auth`
- update API tests to send an authorization header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d7f00c114832aa22b6f121e4130ed